### PR TITLE
Fixed wrong physics in exmaple "tilemaps/mappcollide"

### DIFF
--- a/examples/tilemaps/mapcollide.js
+++ b/examples/tilemaps/mapcollide.js
@@ -18,6 +18,7 @@ var cursors;
 function create() {
 
     game.stage.backgroundColor = '#787878';
+    game.physics.startSystem(Phaser.Physics.ARCADE);
 
     map = game.add.tilemap('mario');
 
@@ -39,8 +40,9 @@ function create() {
     layer.resizeWorld();
 
     p = game.add.sprite(32, 32, 'player');
+    game.physics.enable(p);
 
-    game.physics.gravity.y = 250;
+    game.physics.arcade.gravity.y = 250;
 
     p.body.bounce.y = 0.2;
     p.body.linearDamping = 1;
@@ -54,7 +56,7 @@ function create() {
 
 function update() {
 
-    game.physics.collide(p, layer);
+    game.physics.arcade.collide(p, layer);
 
     p.body.velocity.x = 0;
 
@@ -80,6 +82,6 @@ function update() {
 function render() {
 
     game.debug.cameraInfo(game.camera, 420, 320);
-    game.debug.physicsBody(p.body);
+    game.debug.bodyInfo(p, 32, 320);
 
 }


### PR DESCRIPTION
Hi,

seems like there is an examples which does not work. I don't know but it also seems like this example is a duplicate of "map collide".

Anyway: Here is a pull request which fixes the (maybe obsolete) example ;)
