### PR TITLE
wait for the sample code to be fully loaded before loading run_prettify....

### DIFF
--- a/examples/_site/js/phaser-viewer.js
+++ b/examples/_site/js/phaser-viewer.js
@@ -12,7 +12,11 @@ $(document).ready(function(){
 
 	.done(function(script, textStatus) {
 
-		$.ajax({ url: dir + "/" + file, dataType: "text" }).done(function(data) { $("#sourcecode").text(data); });
+		$.ajax({ url: dir + "/" + file, dataType: "text" })
+			.done(function(data) {
+				$("#sourcecode").text(data);
+				$.getScript("_site/js/run_prettify.js");
+			});
 
 		//	Hook up the control panel
 

--- a/examples/_site/view_full.html
+++ b/examples/_site/view_full.html
@@ -9,7 +9,6 @@
         <script src="_site/js/gamecontroller.js" type="text/javascript"></script>
         <script src="_site/js/phaser.js"></script>
         <script src="_site/js/phaser-viewer.js" type="text/javascript"></script>
-        <script src="_site/js/run_prettify.js"></script>
         <link href="_site/css/phaser-examples.css" media="screen" rel="stylesheet" type="text/css">
         <link href="_site/css/desert.css" rel="stylesheet" type="text/css">
     </head>


### PR DESCRIPTION
Because prettify and example code are loaded asynchronously, the syntax highlighting fails sometime (when prettify loads faster)
This pull request loads prettify only after the example is fully loaded and the code added to the dom.
