### PR TITLE
Fix for Google Chrome and Firefox ignore target attributes when opening ...

### DIFF
--- a/examples/_site/js/phaser-sideview.js
+++ b/examples/_site/js/phaser-sideview.js
@@ -44,6 +44,10 @@ $(document).ready(function(){
 		//	iFrame focus
 		$('a').click(function(e) { $('#viewer').focus(); });
 
+		//  Fix for Chrome ignoring iFrame target links (also occurs with Firefox 29)
+		//  See this issue: https://code.google.com/p/chromium/issues/detail?id=135498
+		function renderInFrame(e) { e.preventDefault(); $('#viewer').prop('src', $(this).attr('href')); }
+		$('a[target=viewer]').on('click', renderInFrame);
 	})
 
 	.fail(function() {


### PR DESCRIPTION
I was using the examples.phaser.io page in the sideview mode in Chrome and the iframe links were opening in a new tab/window instead of the #viewer iframe as intended by the page. This fix makes sure the link opens in the same page (thus enabling the change of examples without loading a new tab every time).

I did not limit this by user agents but I think it should not impair the ability to load the file in the iframe in other browsers which would not have this problem.

See more information regarding the issue here:
https://code.google.com/p/chromium/issues/detail?id=135498
