### PR TITLE
Add grunt-cli to npm devDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   ],
   "devDependencies": {
     "grunt": "~0.4.1",
+    "grunt-cli": "~0.1.13",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-connect": "~0.5.0",
     "grunt-contrib-copy": "~0.5.0",


### PR DESCRIPTION
According to grunt [docs](http://gruntjs.com/getting-started) you will need to install `grunt-cli` package to have `grunt` binary. 

Also the way you need to call `grunt connect` is `./node_modules/grunt-cli/bin/grunt connect`, in other case you'll need to add `-g` to `npm install`. I guess it could be described in README.
