### PR TITLE
Remove duplicated item on index page.

### DIFF
--- a/examples/_site/examples.json
+++ b/examples/_site/examples.json
@@ -263,10 +263,6 @@
       "file": "06+-+render+text.js",
       "title": "06 - render text",
       "jsbin": "http://jsbin.com/zagob/11/edit?js,output"
-    },
-    {
-      "file": "06+-+render+text.js",
-      "title": "06 - render text"
     }
   ],
   "buttons": [


### PR DESCRIPTION
`06 render text` is shown twice on this page http://127.0.0.1:8001/examples/index.html .
