### PR TITLE
Fix for API change to ScaleManager

### DIFF
--- a/projects/bomber/src/Boot.js
+++ b/projects/bomber/src/Boot.js
@@ -48,7 +48,7 @@ Bomber.Boot.prototype = {
             this.scale.pageAlignHorizontally = true;
             this.scale.pageAlignVertically = true;
             this.scale.forceOrientation(true, false);
-            this.scale.hasResized.add(this.gameResized, this);
+            this.scale.setResizeCallback(this.gameResized, this);
             this.scale.enterIncorrectOrientation.add(this.enterIncorrectOrientation, this);
             this.scale.leaveIncorrectOrientation.add(this.leaveIncorrectOrientation, this);
             this.scale.setScreenSize(true);


### PR DESCRIPTION
This was causing the example to fail to load on mobile devices.
