### PR TITLE
fixed 'bmdDest.fastCopy is not a function'

### DIFF
--- a/examples/bitmapdata/fastcopy draw.js
+++ b/examples/bitmapdata/fastcopy draw.js
@@ -47,6 +47,6 @@ function update() {
     bmdDest.fill(0, 0, 0, 0.1);
 
     //  Change the 0.7 at the end, it's the alpha value, lower it for a softer effect
-    bmdDest.fastCopy(bmd, r, game.world.centerX, game.world.centerY, data.r, 0.5, 0.5, data.s, data.s, 0.7);
+    bmdDest.copy(bmd, 0, 0);
 
 }

--- a/examples/demoscene/unlimited bobs.js
+++ b/examples/demoscene/unlimited bobs.js
@@ -56,6 +56,6 @@ function update() {
 
     // bmdDest.draw(floor);
 
-    bmdDest.fastCopy(bmd, r, game.world.centerX, game.world.centerY);
+   bmdDest.copy(bmd, 0, 0);
 
 }


### PR DESCRIPTION
I made the correction to make the examples work, i don't know if achieve the intended behavior, but at least runs without errors
