### PR TITLE
"load an animation" is not using the correct method to load its JSON file

### DIFF
--- a/examples/basics/05 - load an animation.js
+++ b/examples/basics/05 - load an animation.js
@@ -2,7 +2,7 @@
 var game = new Phaser.Game(800, 600, Phaser.AUTO, 'phaser-example', { preload: preload, create: create });
 
 function preload() {
-    game.load.atlasJSONHash('bot', 'assets/sprites/running_bot.png', 'assets/sprites/running_bot.json');
+    game.load.atlasJSONArray('bot', 'assets/sprites/running_bot.png', 'assets/sprites/running_bot.json');
 }
 
 function create() {


### PR DESCRIPTION
In this example, it is using `atlasJSONHash` to load the JSON file for the spritesheet. However, the file that it's loading is a JSON array. Therefore, it seems that it's not using the correct method here, so I changed it to `atlasJSONArray`.
