### PR TITLE
Fix for broken links in local phaser examples

### DIFF
--- a/examples/_site/examples.json
+++ b/examples/_site/examples.json
@@ -195,7 +195,7 @@
       "title": "process callback"
     },
     {
-      "file": "quadtree+-+collision+infos.js",
+      "file": "quadtree+collision+infos.js",
       "title": "quadtree - collision infos"
     },
     {
@@ -259,37 +259,37 @@
   ],
   "basics": [
     {
-      "file": "01+-+load+an+image.js",
+      "file": "01+load+an+image.js",
       "title": "01 - load an image",
       "jsbin": "http://jsbin.com/zagob/1/edit?js,output"
     },
     {
-      "file": "02+-+click+on+an+image.js",
+      "file": "02+click+on+an+image.js",
       "title": "02 - click on an image",
       "jsbin": "http://jsbin.com/zagob/6/edit?js,output"
     },
     {
-      "file": "03+-+move+an+image.js",
+      "file": "03+move+an+image.js",
       "title": "03 - move an image",
       "jsbin": "http://jsbin.com/zagob/7/edit?js,output"
     },
     {
-      "file": "04+-+image+follow+input.js",
+      "file": "04+image+follow+input.js",
       "title": "04 - image follow input",
       "jsbin": "http://jsbin.com/zagob/9/edit?js,output"
     },
     {
-      "file": "05+-+load+an+animation.js",
+      "file": "05+load+an+animation.js",
       "title": "05 - load an animation",
       "jsbin": "http://jsbin.com/zagob/10/edit?js,output"
     },
     {
-      "file": "06+-+render+text.js",
+      "file": "06+render+text.js",
       "title": "06 - render text",
       "jsbin": "http://jsbin.com/zagob/11/edit?js,output"
     },
     {
-      "file": "07+-+tween+an+image.js",
+      "file": "07+tween+an+image.js",
       "title": "07 - tween an image"
     }
   ],
@@ -869,11 +869,11 @@
       "title": "group scale"
     },
     {
-      "file": "group+transform+-+rotate.js",
+      "file": "group+transform+rotate.js",
       "title": "group transform - rotate"
     },
     {
-      "file": "group+transform+-+tween.js",
+      "file": "group+transform+tween.js",
       "title": "group transform - tween"
     },
     {
@@ -913,7 +913,7 @@
       "title": "set All"
     },
     {
-      "file": "sub+groups+-+group+length.js",
+      "file": "sub+groups+group+length.js",
       "title": "sub groups - group length"
     },
     {
@@ -1011,11 +1011,11 @@
       "title": "keyboard"
     },
     {
-      "file": "motion+lock+-+horizontal.js",
+      "file": "motion+lock+horizontal.js",
       "title": "motion lock - horizontal"
     },
     {
-      "file": "motion+lock+-+vertical.js",
+      "file": "motion+lock+vertical.js",
       "title": "motion lock - vertical"
     },
     {
@@ -1035,19 +1035,19 @@
       "title": "pixel perfect click detection"
     },
     {
-      "file": "pixelpick+-+atlas+scaled.js",
+      "file": "pixelpick+atlas+scaled.js",
       "title": "pixelpick - atlas scaled"
     },
     {
-      "file": "pixelpick+-+atlas.js",
+      "file": "pixelpick+atlas.js",
       "title": "pixelpick - atlas"
     },
     {
-      "file": "pixelpick+-+scrolling+effect.js",
+      "file": "pixelpick+scrolling+effect.js",
       "title": "pixelpick - scrolling effect"
     },
     {
-      "file": "pixelpick+-+spritesheet.js",
+      "file": "pixelpick+spritesheet.js",
       "title": "pixelpick - spritesheet"
     },
     {

--- a/examples/arcade physics/quadtree collision infos.js
+++ b/examples/arcade physics/quadtree collision infos.js
@@ -1,0 +1,72 @@
+
+var game = new Phaser.Game(800, 600, Phaser.CANVAS, 'phaser-example', { preload: preload, create: create, update: update, render: render });
+
+function preload() {
+
+    game.load.image('ship', 'assets/sprites/xenon2_ship.png');
+    game.load.image('baddie', 'assets/sprites/space-baddie.png');
+
+}
+
+var ship;
+var aliens;
+var cursors;
+
+function create() {
+
+    game.physics.startSystem(Phaser.Physics.ARCADE);
+
+    //  Enable the QuadTree
+    game.physics.arcade.skipQuadTree = false;
+
+    aliens = game.add.group();
+    aliens.enableBody = true;
+
+    for (var i = 0; i < 50; i++)
+    {
+        var s = aliens.create(game.world.randomX, game.world.randomY, 'baddie');
+        s.body.collideWorldBounds = true;
+        s.body.bounce.set(1);
+        s.body.velocity.setTo(10 + Math.random() * 40, 10 + Math.random() * 40);
+    }
+
+    ship = game.add.sprite(400, 400, 'ship');
+
+    game.physics.enable(ship, Phaser.Physics.ARCADE);
+
+    ship.body.collideWorldBounds = true;
+    ship.body.bounce.set(1);
+
+    cursors = game.input.keyboard.createCursorKeys();
+
+}
+
+function update() {
+
+    game.physics.arcade.collide(ship, aliens);
+
+    if (cursors.left.isDown)
+    {
+        ship.body.velocity.x -= 4;
+    }
+    else if (cursors.right.isDown)
+    {
+        ship.body.velocity.x += 4;
+    }
+
+    if (cursors.up.isDown)
+    {
+        ship.body.velocity.y -= 4;
+    }
+    else if (cursors.down.isDown)
+    {
+        ship.body.velocity.y += 4;
+    }
+
+}
+
+function render() {
+
+    game.debug.quadTree(game.physics.arcade.quadTree);
+
+}


### PR DESCRIPTION
Fixed an issue with the examples where source files had the hyphens removed, but the JSON mapping did not reflect this change, causing examples to not work through the provided index file. I also changed the name of the 'quadtree collision infos.js' file to match the rest of the files.
