### PR TITLE
Fixing Lightbeams example

### DIFF
--- a/examples/filters/lightbeams.js
+++ b/examples/filters/lightbeams.js
@@ -7,7 +7,7 @@ var filter;
 function preload() {
 
     game.load.image('phaser', 'assets/sprites/phaser2.png');
-    game.load.script('filter', '../filters/LightBeam.js');
+    game.load.script('filter', 'https://cdn.rawgit.com/photonstorm/phaser/master/filters/LightBeam.js');
 
 }
 


### PR DESCRIPTION
The [Lightbeams example](http://phaser.io/examples/v2/filters/lightbeams) is broken due to an invalid filter path.
