### PR TITLE
Adds linting (ala jshint) to examples

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,7 @@
 module.exports = function (grunt) {
 
+    grunt.loadNpmTasks('grunt-contrib-jshint');
+
     grunt.loadNpmTasks('grunt-contrib-connect');
 
     grunt.loadTasks('./tasks');
@@ -25,7 +27,19 @@ module.exports = function (grunt) {
                     port: 8001
                 }
             }
+        },
+
+	jshint: {
+        all: [
+	        'examples/**/*.js',
+		    '!!examples/_site/**',
+		    '!!examples/_plugins/**',
+		    '!!examples/wip/**'
+	    ],
+        options: {
+	        jshintrc: 'tasks/jshint.json'
         }
+	}
 
     });
 

--- a/examples/animation/dragonBones.js
+++ b/examples/animation/dragonBones.js
@@ -1,3 +1,4 @@
+/* jshint ignore:start */
 var __extends = this.__extends || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }

--- a/examples/animation/dragon_bones.js
+++ b/examples/animation/dragon_bones.js
@@ -28,7 +28,7 @@ var ScriptLoader = (function(){
             if (this.readyState == 'complete') {
                 p_callback();
             }
-        }
+        };
         head.appendChild(script);
     }
     return {load:load};
@@ -42,9 +42,10 @@ var ScriptLoader = (function(){
 
 //the phaser game object
 var game = null;
+var dragonBones;
 
 //wait for scripts to load first
-ScriptLoader.load(["animation/dragonBones.js","animation/phaser_dragonbones.js"], createGame)
+ScriptLoader.load(["animation/dragonBones.js","animation/phaser_dragonbones.js"], createGame);
 
 //now instantiate the game
 function createGame(){
@@ -79,7 +80,7 @@ function update() {
     // For simplicity just using a hardcoded value of 0.02 secs
     // but ideally should evaluate how much time has really passed since last call
     // and send that value through instead -> eg use Date.now()
-    dragonBones.animation.WorldClock.clock.advanceTime(0.02)
+    dragonBones.animation.WorldClock.clock.advanceTime(0.02);
 }
 
 

--- a/examples/animation/group creation.js
+++ b/examples/animation/group creation.js
@@ -19,7 +19,7 @@ function create() {
     for (var i = 0; i < 6; i++)
     {
         //  They are evenly spaced out on the X coordinate, with a random Y coordinate
-        sprite = group.create(120 * i, game.rnd.integerInRange(100, 400), 'seacreatures', 'octopus0000');
+        var sprite = group.create(120 * i, game.rnd.integerInRange(100, 400), 'seacreatures', 'octopus0000');
     }
 
     //  These are the frame names for the octopus animation. We use the generateFrames function to help create the array.

--- a/examples/animation/phaser_dragonbones.js
+++ b/examples/animation/phaser_dragonbones.js
@@ -1,3 +1,4 @@
+/* jshint ignore:start */
 var dragonBones;
 (function (dragonBones) {
     (function (display) {

--- a/examples/arcade physics/bounce accelerator.js
+++ b/examples/arcade physics/bounce accelerator.js
@@ -10,6 +10,7 @@ function preload() {
 }
 
 var flyer;
+var cursors;
 
 function create() {
 

--- a/examples/arcade physics/bounce knock.js
+++ b/examples/arcade physics/bounce knock.js
@@ -11,6 +11,9 @@ function preload() {
 }
 
 var image;
+var ball;
+var knocker;
+var cursors;
 
 function create() {
 

--- a/examples/arcade physics/custom sprite vs group.js
+++ b/examples/arcade physics/custom sprite vs group.js
@@ -1,6 +1,6 @@
-Vegetable = function (game) {
+var Vegetable = function (game) {
 
-    frame = game.rnd.between(0, 35);
+    var frame = game.rnd.between(0, 35);
 
     //  Just because we don't want a false chilli (frame 17)
     if (frame === 17)
@@ -18,7 +18,7 @@ Vegetable = function (game) {
 Vegetable.prototype = Object.create(Phaser.Image.prototype);
 Vegetable.prototype.constructor = Vegetable;
 
-Chilli = function (game) {
+var Chilli = function (game) {
 
     var x = game.rnd.between(100, 770);
     var y = game.rnd.between(0, 570);

--- a/examples/arcade physics/launcher follow world.js
+++ b/examples/arcade physics/launcher follow world.js
@@ -18,6 +18,7 @@ var arrow;
 var catchFlag = false;
 var launchVelocity = 0;
 var launched;
+var analog;
 
 function create() {
     
@@ -89,8 +90,8 @@ function launch() {
     
         arrow.alpha = 0;
         analog.alpha = 0;
-        Xvector = (arrow.x - player.x) * 3;
-        Yvector = (arrow.y - player.y) * 3; 
+        var Xvector = (arrow.x - player.x) * 3;
+        var Yvector = (arrow.y - player.y) * 3; 
         player.body.moves = true;
         player.body.gravity.setTo(0, 180);
         player.body.velocity.setTo(Xvector, Yvector);
@@ -104,15 +105,15 @@ function update() {
     //  Track the player sprite to the mouse    
     if (catchFlag)
     {   
-        distance = game.physics.arcade.distanceToPointer(arrow);
-        theta = game.physics.arcade.angleToPointer(arrow);
+        var distance = game.physics.arcade.distanceToPointer(arrow);
+        var theta = game.physics.arcade.angleToPointer(arrow);
         
         // Govern the distance the sprite is dragged away from launch post
         if (distance > 300)
         { 
             distance = 300;
-            adjacentX = Math.cos(theta) * distance;
-            oppositeY = Math.sin(theta) * distance;
+            var adjacentX = Math.cos(theta) * distance;
+            var oppositeY = Math.sin(theta) * distance;
             player.x = 400 + adjacentX;
             player.y = 400 + oppositeY;
             analog.height = distance;
@@ -133,7 +134,7 @@ function update() {
     //check sprite motion and if done, return camera to left side of world
     var tweening = myTween.isRunning;
 
-    if (!tweening && launched && (player.x >= game.world.width-20 || player.body.deltaX() == 0))
+    if (!tweening && launched && (player.x >= game.world.width-20 || player.body.deltaX() === 0))
     {
         player.body.velocity.setTo(0, 0);
         player.alpha = 0;

--- a/examples/arcade physics/launcher follow.js
+++ b/examples/arcade physics/launcher follow.js
@@ -17,6 +17,7 @@ var cursors;
 var arrow;
 var catchFlag = false;
 var launchVelocity = 0;
+var analog;
 
 function create() {
     
@@ -75,8 +76,8 @@ function launch() {
     arrow.alpha = 0;
     analog.alpha = 0;
 
-    Xvector = (arrow.x - player.x) * 3;
-    Yvector = (arrow.y - player.y) * 3;
+    var Xvector = (arrow.x - player.x) * 3;
+    var Yvector = (arrow.y - player.y) * 3;
 
     player.body.velocity.setTo(Xvector, Yvector);
 
@@ -86,7 +87,7 @@ function update() {
 
     arrow.rotation = game.physics.arcade.angleBetween(arrow, player);
     
-    if (catchFlag == true)
+    if (catchFlag)
     {
         //  Track the ball sprite to the mouse  
         player.x = game.input.activePointer.worldX; 

--- a/examples/arcade physics/launcher.js
+++ b/examples/arcade physics/launcher.js
@@ -11,6 +11,7 @@ function preload() {
 
 }
 
+var analog;
 var arrow;
 var ball;
 var catchFlag = false;
@@ -77,8 +78,8 @@ function launch() {
     ball.body.moves = true;
     arrow.alpha = 0;
     analog.alpha = 0;
-    Xvector = (arrow.x - ball.x) * 3;
-    Yvector = (arrow.y - ball.y) * 3;
+    var Xvector = (arrow.x - ball.x) * 3;
+    var Yvector = (arrow.y - ball.y) * 3;
     ball.body.allowGravity = true;  
     ball.body.velocity.setTo(Xvector, Yvector);
 
@@ -88,7 +89,7 @@ function update() {
 
     arrow.rotation = game.physics.arcade.angleBetween(arrow, ball);
     
-    if (catchFlag == true)
+    if (catchFlag)
     {
         //  Track the ball sprite to the mouse  
         ball.x = game.input.activePointer.worldX;   

--- a/examples/arcade physics/move to pointer.js
+++ b/examples/arcade physics/move to pointer.js
@@ -47,3 +47,6 @@ function render() {
     game.debug.text("distance: " + game.physics.arcade.distanceToPointer(ball), 32, 32);
 
 }
+
+function update() {    
+}

--- a/examples/arcade physics/snake.js
+++ b/examples/arcade physics/snake.js
@@ -10,10 +10,11 @@ function preload() {
 }
 
 var snakeHead; //head of snake sprite
-var snakeSection = new Array(); //array of sprites that make the snake body sections
-var snakePath = new Array(); //arrary of positions(points) that have to be stored for the path the sections follow
+var snakeSection = []; //array of sprites that make the snake body sections
+var snakePath = []; //arrary of positions(points) that have to be stored for the path the sections follow
 var numSnakeSections = 30; //number of snake body sections
 var snakeSpacer = 6; //parameter that sets the spacing between sections
+var cursors;
 
 function create() {
 

--- a/examples/audio/fade in.js
+++ b/examples/audio/fade in.js
@@ -9,6 +9,7 @@ function preload() {
 }
 
 var music;
+var sprite;
 
 function create() {
 
@@ -18,8 +19,8 @@ function create() {
     music = game.add.audio('boden');
     music.onDecoded.add(start, this);
 
-    s = game.add.sprite(game.world.centerX, game.world.centerY, 'disk');
-    s.anchor.setTo(0.5, 0.5);
+    sprite = game.add.sprite(game.world.centerX, game.world.centerY, 'disk');
+    sprite.anchor.setTo(0.5, 0.5);
 
 }
 

--- a/examples/audio/protracker.js
+++ b/examples/audio/protracker.js
@@ -37,7 +37,14 @@ function modLoaded(key, data) {
 
 function load_next_module()
 {
-    current == mods.length - 1 ? current = 0 : current++;
+    if (current == mods.length - 1)
+    {
+        current = 0;
+    }
+    else
+    {
+        current++;
+    }
 
     module.stop();
     module.clearsong();

--- a/examples/audio/ym.js
+++ b/examples/audio/ym.js
@@ -56,7 +56,7 @@ var musics = [
         file: 'assets/audio/ym/mad_max-wings_of_death1.ym'
     }
 
-]
+];
 
 function preload() {
 

--- a/examples/bitmapdata/alpha mask.js
+++ b/examples/bitmapdata/alpha mask.js
@@ -12,10 +12,10 @@ function create() {
 
 	game.stage.backgroundColor = 0x4d4d4d;
 
-	game.add.text(64, 10, 'Source image', { font: '16px Arial', fill: '#ffffff' })
+	game.add.text(64, 10, 'Source image', { font: '16px Arial', fill: '#ffffff' });
 	game.add.image(64, 32, 'pic');
 
-	game.add.text(400, 10, 'Alpha mask', { font: '16px Arial', fill: '#ffffff' })
+	game.add.text(400, 10, 'Alpha mask', { font: '16px Arial', fill: '#ffffff' });
 	game.add.image(400, 32, 'mask');
 
 	//	Create a new bitmap data the same size as our picture

--- a/examples/bitmapdata/fastcopy draw.js
+++ b/examples/bitmapdata/fastcopy draw.js
@@ -6,6 +6,7 @@ var r;
 var bmd;
 var bmdDest;
 var colors;
+var data;
 
 function create() {
 

--- a/examples/box2d/car on terrain.js
+++ b/examples/box2d/car on terrain.js
@@ -36,6 +36,7 @@ var truckVertices = [-0.941074,-7.13798,-69.9798,-7.91197,-73.1929,8.39935,-68.3
 
 var truckBody;
 var driveJoints = [];
+var cursors;
 
 function create() {
 	

--- a/examples/box2d/chain.js
+++ b/examples/box2d/chain.js
@@ -42,9 +42,10 @@ function createRope(length, xAnchor,yAnchor){
     {
         var x = xAnchor;
         var y = yAnchor + (i * height);
+        var newRect;
         
         // Switch sprite every second time
-        if (i % 2 == 0)
+        if (i % 2 === 0)
         {
             newRect = game.add.sprite(x, y, 'chain',1);
         }
@@ -56,7 +57,7 @@ function createRope(length, xAnchor,yAnchor){
 
         game.physics.box2d.enable(newRect,false);
 
-        if (i == 0)
+        if (i === 0)
         {
             newRect.body.static=true;
         }

--- a/examples/box2d/circle body.js
+++ b/examples/box2d/circle body.js
@@ -16,7 +16,7 @@ function preload() {
 
 }
 
-var circle
+var circle;
 
 function create() {
     

--- a/examples/box2d/collision impulses.js
+++ b/examples/box2d/collision impulses.js
@@ -20,6 +20,7 @@ function preload() {
 
 var caption1;
 var caption2;
+var ship;
 
 function create() {
     

--- a/examples/box2d/domino tower.js
+++ b/examples/box2d/domino tower.js
@@ -17,7 +17,7 @@ function preload() {
 
 }
 
-_debugType = 
+var _debugType = 
 {
     NONE    : 0,
     SOME    : 1,
@@ -66,7 +66,7 @@ function create() {
             topSprite = game.add.sprite(xpos, startY, 'phaser');
             game.physics.box2d.enable(topSprite);
 
-            if (layerType == 0)
+            if (layerType === 0)
             {
                 topSprite.body.angle = 90;
             }
@@ -83,7 +83,7 @@ function create() {
         }
         
         // end pieces
-        if (layerType == 0 && count > 0)
+        if (layerType === 0 && count > 0)
         {
             topSprite = game.add.sprite(startX - spriteHeight - 0.5 * spriteWidth, startY + spriteWidth, 'phaser');
             game.physics.box2d.enable(topSprite);

--- a/examples/box2d/pinball.js
+++ b/examples/box2d/pinball.js
@@ -40,11 +40,13 @@ var rightFlipperVertices = [0,64,0,-64,-560,-32,-560,32];
 
 var ballStart = [17.5016, -21.318];
 
-
+var gutterFixture;
 var ballBody;
 var flipperJoints = [];
 var PTM = 100; // conversion ratio for values in arrays above
 var needReset = false;
+
+var cursors;
 
 function create() {
     

--- a/examples/box2d/polygon decomposition.js
+++ b/examples/box2d/polygon decomposition.js
@@ -37,10 +37,10 @@ function create() {
     for (var i = 0; i < 6; i++)
     {
         // offscreen to start with
-        var sprite = game.add.sprite(1000, 200, i % 2 == 0 ? 'ball':'firstaid');
+        var sprite = game.add.sprite(1000, 200, i % 2 === 0 ? 'ball':'firstaid');
         game.physics.box2d.enable(sprite);
 
-        if (i % 2 == 0)
+        if (i % 2 === 0)
         {
             sprite.body.setCircle(16);
         }       

--- a/examples/box2d/projected trajectory.js
+++ b/examples/box2d/projected trajectory.js
@@ -137,7 +137,7 @@ function render() {
     {
         var trajectoryPoint = getTrajectoryPoint(launchX, launchY, launchVelocity.x, launchVelocity.y, i);
 
-        if (lastPos && i % 12 == 0)
+        if (lastPos && i % 12 === 0)
         {
             line(lastPos.x, lastPos.y, trajectoryPoint.x, trajectoryPoint.y);
         }

--- a/examples/box2d/raycasting.js
+++ b/examples/box2d/raycasting.js
@@ -20,7 +20,7 @@ function preload() {
 
 }
 
-_raycastType = 
+var _raycastType = 
 {
     CLOSEST : 0,
     ALL     : 1,

--- a/examples/box2d/slider crank.js
+++ b/examples/box2d/slider crank.js
@@ -29,7 +29,7 @@ function create() {
     var crank = new Phaser.Physics.Box2D.Body(this.game, null, game.world.centerX, 450, 2);
     crank.setRectangle(15, 75, 0, 0, 0);
     //Revolute joint with motor enabled attaching the crank to the ground. This is where all the power for the slider crank comes from
-    game.physics.box2d.revoluteJoint(ground, crank, 0, -160, 0, 30, 250, 50, true)
+    game.physics.box2d.revoluteJoint(ground, crank, 0, -160, 0, 30, 250, 50, true);
     
     //  Tall skinny rectangle body for the arm. Connects the crank to the piston
     var arm = new Phaser.Physics.Box2D.Body(this.game, null, game.world.centerX, 360, 2);

--- a/examples/box2d/spring.js
+++ b/examples/box2d/spring.js
@@ -17,6 +17,7 @@ function preload() {
 var platform1;
 var platform2;
 var platform3;
+var codeCaption;
 
 function create() {
     

--- a/examples/box2d/world bounds.js
+++ b/examples/box2d/world bounds.js
@@ -21,6 +21,7 @@ function preload() {
 
 var ship;
 var starfield;
+var balls;
 var cursors;
 
 function create() {
@@ -37,9 +38,9 @@ function create() {
 
     for (var i = 0; i < 50; i++)
     {
-        var sprite = balls.create(game.world.randomX, game.world.randomY, i % 2 == 0 ? 'ball' : 'firstaid');
+        var sprite = balls.create(game.world.randomX, game.world.randomY, i % 2 === 0 ? 'ball' : 'firstaid');
 
-        if (i % 2 == 0)
+        if (i % 2 === 0)
         {
             sprite.body.setCircle(16);
         }

--- a/examples/box2d/world querying.js
+++ b/examples/box2d/world querying.js
@@ -25,6 +25,7 @@ var _queryType =
 };
 
 var caption;
+var polygonBody;
 var queryType = _queryType.POLYGON; // will roll over to AABB in create()
 var circleBody, circleFixture;
 var polygBody, polygonFixture;

--- a/examples/camera/basic follow.js
+++ b/examples/camera/basic follow.js
@@ -35,7 +35,7 @@ function update() {
 
     if (cursors.up.isDown)
     {
-        player.body.moveUp(300)
+        player.body.moveUp(300);
     }
     else if (cursors.down.isDown)
     {

--- a/examples/camera/deadzone.js
+++ b/examples/camera/deadzone.js
@@ -41,7 +41,7 @@ function update() {
 
     if (cursors.up.isDown)
     {
-        player.body.moveUp(300)
+        player.body.moveUp(300);
     }
     else if (cursors.down.isDown)
     {

--- a/examples/camera/follow styles.js
+++ b/examples/camera/follow styles.js
@@ -48,10 +48,10 @@ function create() {
     game.camera.follow(ufo);
 
     // follow style switch buttons
-    btn0 = game.add.button(6, 40, 'button', lockonFollow,this, 0, 0, 0);
-    btn1 = game.add.button(6, 120, 'button', platformerFollow,this, 1, 1, 1);
-    btn2 = game.add.button(6, 200, 'button', topdownFollow,this, 2, 2, 2);
-    btn3 = game.add.button(6, 280, 'button', topdownTightFollow,this, 3, 3, 3);
+    var btn0 = game.add.button(6, 40, 'button', lockonFollow,this, 0, 0, 0);
+    var btn1 = game.add.button(6, 120, 'button', platformerFollow,this, 1, 1, 1);
+    var btn2 = game.add.button(6, 200, 'button', topdownFollow,this, 2, 2, 2);
+    var btn3 = game.add.button(6, 280, 'button', topdownTightFollow,this, 3, 3, 3);
 
     cursors = game.input.keyboard.createCursorKeys();
 

--- a/examples/create/gen paint.js
+++ b/examples/create/gen paint.js
@@ -45,6 +45,7 @@ var isErase = false;
 //  Palette
 var ci = 0;
 var color = 0;
+var colorIndex = 0;
 var palette = 0;
 var pmap = [0,1,2,3,4,5,6,7,8,9,'A','B','C','D','E','F'];
 

--- a/examples/create/gradient gen.js
+++ b/examples/create/gradient gen.js
@@ -206,7 +206,7 @@ function refresh() {
         distance = sy - dy;
         y = dy;
         step = Math.floor(distance / chunk);
-        remainder = distance - (step * chunk);
+        var remainder = distance - (step * chunk);
 
         for (var i = 0; i < step; i++)
         {

--- a/examples/create/polyline.js
+++ b/examples/create/polyline.js
@@ -16,7 +16,7 @@ function create() {
     bmd = game.make.bitmapData(800, 600);
     bmd.addToWorld();
 
-    keys = game.input.keyboard.addKeys(
+    var keys = game.input.keyboard.addKeys(
         {
             'close': Phaser.Keyboard.SPACEBAR,
             'save': Phaser.Keyboard.S

--- a/examples/create/rat attack.js
+++ b/examples/create/rat attack.js
@@ -1,6 +1,10 @@
 
 var game = new Phaser.Game(800, 600, Phaser.CANVAS, 'phaser-example', this);
 
+var player;
+var cursors;
+var rats;
+
 function create() {
 
     game.physics.startSystem(Phaser.Physics.ARCADE);

--- a/examples/demoscene/font from bitmapdata.js
+++ b/examples/demoscene/font from bitmapdata.js
@@ -62,28 +62,6 @@ function create() {
 
 }
 
-function setLetters() {
-
-    page++;
-
-    if (page === 3)
-    {
-        page = 0;
-    }
-
-    var i = 0;
-
-    for (var y = 0; y < 8; y++)
-    {
-        for (var x = 0; x < 10; x++)
-        {
-            letters[i].frame = font.grabData[scroller[(page * 8) + y].charCodeAt(x)];
-            i++;
-        }
-    }
-
-}
-
 function update() {
 
     raster.cls();

--- a/examples/demoscene/raster font.js
+++ b/examples/demoscene/raster font.js
@@ -10,6 +10,7 @@ function preload() {
 
 var font;
 var alpha;
+var raster;
 var mask = new Phaser.Rectangle();
 
 function create() {

--- a/examples/demoscene/textwriter.js
+++ b/examples/demoscene/textwriter.js
@@ -23,6 +23,7 @@ var page = -1;
 
 var bfont;
 var alpha;
+var raster;
 var mask = new Phaser.Rectangle();
 
 var scroller = [ 

--- a/examples/demoscene/wobble.js
+++ b/examples/demoscene/wobble.js
@@ -9,8 +9,7 @@ function preload() {
 }
 
 var stars;
-var waveformX;
-var waveformY;
+var waveform;
 
 var xl;
 var yl;

--- a/examples/display/pixi render texture.js
+++ b/examples/display/pixi render texture.js
@@ -69,7 +69,7 @@ function update() {
 	outputSprite.setTexture(renderTexture);
 
 	// twist this up!
-	stuffContainer.rotation -= 0.01
+	stuffContainer.rotation -= 0.01;
 	outputSprite.scale.x = outputSprite.scale.y  = 1 + Math.sin(count) * 0.2;
 
 	// render the stage to the texture

--- a/examples/display/render texture starfield.js
+++ b/examples/display/render texture starfield.js
@@ -67,7 +67,7 @@ function update() {
             stars[i].y = -32;
         }
 
-        if (i == 0 || i == 100 || i == 200)
+        if (i === 0 || i === 100 || i === 200)
         {
             //  If it's the first star of the layer then we clear the texture
             stars[i].texture.renderXY(star, stars[i].x, stars[i].y, true);

--- a/examples/games/breakout.js
+++ b/examples/games/breakout.js
@@ -158,7 +158,7 @@ function ballHitBrick (_ball, _brick) {
     scoreText.text = 'score: ' + score;
 
     //  Are they any bricks left?
-    if (bricks.countLiving() == 0)
+    if (bricks.countLiving() === 0)
     {
         //  New level starts
         score += 1000;

--- a/examples/games/invaders.js
+++ b/examples/games/invaders.js
@@ -16,6 +16,7 @@ function preload() {
 var player;
 var aliens;
 var bullets;
+var enemyBullets;
 var bulletTime = 0;
 var cursors;
 var fireButton;
@@ -200,7 +201,7 @@ function collisionHandler (bullet, alien) {
     explosion.reset(alien.body.x, alien.body.y);
     explosion.play('kaboom', 30, false, true);
 
-    if (aliens.countLiving() == 0)
+    if (aliens.countLiving() === 0)
     {
         score += 1000;
         scoreText.text = scoreString + score;
@@ -219,7 +220,7 @@ function enemyHitsPlayer (player,bullet) {
     
     bullet.kill();
 
-    live = lives.getFirstAlive();
+    var live = lives.getFirstAlive();
 
     if (live)
     {
@@ -249,7 +250,7 @@ function enemyHitsPlayer (player,bullet) {
 function enemyFires () {
 
     //  Grab the first bullet we can from the pool
-    enemyBullet = enemyBullets.getFirstExists(false);
+    var enemyBullet = enemyBullets.getFirstExists(false);
 
     livingEnemies.length=0;
 
@@ -282,7 +283,7 @@ function fireBullet () {
     if (game.time.now > bulletTime)
     {
         //  Grab the first bullet we can from the pool
-        bullet = bullets.getFirstExists(false);
+        var bullet = bullets.getFirstExists(false);
 
         if (bullet)
         {

--- a/examples/games/matching pairs.js
+++ b/examples/games/matching pairs.js
@@ -12,8 +12,8 @@ function preload() {
 var timeCheck = 0;
 var flipFlag = false;
 
-var startList = new Array();
-var squareList = new Array();
+var startList = [];
+var squareList = [];
 
 var masterCounter = 0;
 var squareCounter = 0;
@@ -32,12 +32,12 @@ var marker;
 var currentTile;
 var currentTilePosition;
 
+var myCountdownSeconds;
+var currentNum;
+
 var tileBack = 25;
 var timesUp = '+';
 var youWin = '+';
-
-var myCountdownSeconds;
-
 
 function create() {
 
@@ -69,7 +69,7 @@ function update() {
         marker.y = layer.getTileY(game.input.activePointer.worldY) * 100;
     }
 
-    if (flipFlag == true) 
+    if (flipFlag) 
     {
         if (game.time.totalElapsedSeconds() - timeCheck > 0.5)
         {
@@ -87,7 +87,7 @@ function countDownTimer() {
   
     var timeLimit = 120;
   
-    mySeconds = game.time.totalElapsedSeconds();
+    var mySeconds = game.time.totalElapsedSeconds();
     myCountdownSeconds = timeLimit - mySeconds;
     
     if (myCountdownSeconds <= 0) 
@@ -108,9 +108,9 @@ function processClick() {
         if (currentTile.index == tileBack)
         {
             // get the corresponding item out of squareList
-                currentNum = squareList[currentTilePosition-1];
+            var currentNum = squareList[currentTilePosition-1];
             flipOver();
-                squareCounter++;
+            squareCounter++;
             // is the second tile of pair flipped?
             if  (squareCounter == 2) 
             {
@@ -162,6 +162,7 @@ function flipBack() {
  
 function randomizeTiles() {
 
+    var num;
     for (num = 1; num <= 18; num++)
     {
         startList.push(num);
@@ -170,11 +171,9 @@ function randomizeTiles() {
     {
         startList.push(num);
     }
-
-    // for debugging
-    myString1 = startList.toString();
   
     // randomize squareList
+    var i;
     for (i = 1; i <=36; i++)
     {
         var randomPosition = game.rnd.integerInRange(0,startList.length - 1);
@@ -186,10 +185,8 @@ function randomizeTiles() {
 
         startList.splice( a, 1);
     }
-    
-    // for debugging
-    myString2 = squareList.toString();
-  
+      
+    var col, row;
     for (col = 0; col < 6; col++)
     {
         for (row = 0; row < 6; row++)
@@ -201,8 +198,9 @@ function randomizeTiles() {
 
 function getHiddenTile() {
         
-    thisTile = squareList[currentTilePosition-1];
+    var thisTile = squareList[currentTilePosition-1];
     return thisTile;
+
 }
 
 function render() {

--- a/examples/games/simon.js
+++ b/examples/games/simon.js
@@ -17,12 +17,12 @@ var sequenceList = [];
 var simonSez = false;
 var timeCheck;
 var litSquare;
+var thisSquare;
 var winner;
 var loser;
 var intro;
 
 function create() {
-
     simon = game.add.group();
     var item;
 
@@ -77,7 +77,7 @@ function introTween() {
     for (var i = 0; i < 6; i++)
     {
         var flashing = game.add.tween(simon.getAt(i)).to( { alpha: 1 }, 500, Phaser.Easing.Linear.None, true, 0, 4, true);
-        var final = game.add.tween(simon.getAt(i)).to( { alpha: .25 }, 500, Phaser.Easing.Linear.None, true);
+        var final = game.add.tween(simon.getAt(i)).to( { alpha: 0.25 }, 500, Phaser.Easing.Linear.None, true);
 
         flashing.chain(final);
         flashing.start();
@@ -91,7 +91,7 @@ function update() {
     {
         if (game.time.now - timeCheck >700-N*40)
         {
-            simon.getAt(litSquare).alpha = .25;
+            simon.getAt(litSquare).alpha = 0.25;
             game.paused = true;
 
             setTimeout(function()
@@ -113,7 +113,7 @@ function update() {
 
 function playerSequence(selected) {
 
-    correctSquare = sequenceList[userCount];
+    var correctSquare = sequenceList[userCount];
     userCount++;
     thisSquare = simon.getIndex(selected);
 
@@ -176,7 +176,7 @@ function release(item, pointer) {
 
     if (!simonSez && !intro && !loser && !winner)
     {
-        item.alpha = .25;
+        item.alpha = 0.25;
         playerSequence(item);
     }
 }
@@ -185,7 +185,7 @@ function moveOff(item, pointer) {
 
     if (!simonSez && !intro && !loser && !winner)
     {
-        item.alpha = .25;
+        item.alpha = 0.25;
     }
 
 }

--- a/examples/games/tanks.js
+++ b/examples/games/tanks.js
@@ -1,5 +1,5 @@
 
-EnemyTank = function (index, game, player, bullets) {
+var EnemyTank = function (index, game, player, bullets) {
 
     var x = game.world.randomX;
     var y = game.world.randomY;
@@ -49,7 +49,7 @@ EnemyTank.prototype.damage = function() {
 
     return false;
 
-}
+};
 
 EnemyTank.prototype.update = function() {
 

--- a/examples/games/yahtzee.js
+++ b/examples/games/yahtzee.js
@@ -181,7 +181,7 @@ var ComboSingle = function (game, value) {
         this.score = dice.total;
         this.played = true;
 
-    }
+    };
 
 };
 
@@ -218,7 +218,7 @@ var ComboChance = function (game) {
 
         this.played = true;
 
-    }
+    };
 
 };
 
@@ -359,7 +359,7 @@ var ComboXOfAKind = function (game, value, points) {
 
         this.played = true;
 
-    }
+    };
 
 };
 

--- a/examples/groups/bring a group to top.js
+++ b/examples/groups/bring a group to top.js
@@ -38,7 +38,7 @@ function create() {
 
         //  Sonics
 
-        var tempSprite=game.add.sprite(game.world.randomX, game.world.randomY, 'sonic');
+        var tempSprite = game.add.sprite(game.world.randomX, game.world.randomY, 'sonic');
 
         tempSprite.name = 'sonic' + i;
         tempSprite.inputEnabled = true;

--- a/examples/groups/depth sort.js
+++ b/examples/groups/depth sort.js
@@ -46,18 +46,19 @@ function create() {
 
 function createUniqueLocation() {
 
+    var x, y, idx;
     do {
-        var x = game.math.snapTo(game.world.randomX, 32) / 32;
-        var y = game.math.snapTo(game.world.randomY, 32) / 32;
+        x = game.math.snapTo(game.world.randomX, 32) / 32;
+        y = game.math.snapTo(game.world.randomY, 32) / 32;
 
         if (y > 17)
         {
             y = 17;
         }
 
-        var idx = (y * 17) + x;
+        idx = (y * 17) + x;
     }
-    while (locs.indexOf(idx) !== -1)
+    while (locs.indexOf(idx) !== -1);
 
     locs.push(idx);
 

--- a/examples/groups/extending a group.js
+++ b/examples/groups/extending a group.js
@@ -1,7 +1,7 @@
 //  Here is a custom group
 //  It will automatically create 30 sprites of the given image when created.
 
-MonsterGroup = function (game, image, action) {
+var MonsterGroup = function (game, image, action) {
 
     Phaser.Group.call(this, game);
 

--- a/examples/groups/replace.js
+++ b/examples/groups/replace.js
@@ -7,7 +7,7 @@ function preload() {
 }
 
 // Left and right groups
-var left
+var left;
 var right;
 
 // The first selected item.

--- a/examples/input/button destroy.js
+++ b/examples/input/button destroy.js
@@ -8,6 +8,7 @@ function preload() {
 }
 
 var button;
+var text;
 
 function create() {
 

--- a/examples/input/gamepad analog button.js
+++ b/examples/input/gamepad analog button.js
@@ -11,6 +11,7 @@ function preload() {
 
 var pad;
 var leftTriggerButton;
+var rightTriggerButton;
 var leftTriggerGfx;
 var rightTriggerGfx;
 

--- a/examples/input/gamepad debug.js
+++ b/examples/input/gamepad debug.js
@@ -79,10 +79,10 @@ function update() {
 
 function updatePadStatusText(rawPad, padText, num) {
     if(rawPad) {
-        padText.setText('Pad '+num+': [ index: '+rawPad['index']+' | id: '+rawPad['id']
-            +' | timestamp: '+rawPad['timestamp']+']'
-            +' | buttons: '+rawPad.buttons.length
-            +' | axes: '+rawPad.axes.length
+        padText.setText('Pad '+num+': [ index: '+rawPad.index+' | id: '+rawPad.id +
+            ' | timestamp: '+rawPad.timestamp+']' +
+            ' | buttons: '+rawPad.buttons.length +
+            ' | axes: '+rawPad.axes.length
         );
     } else {
         padText.setText('Pad '+num+': Not connected');

--- a/examples/input/gamepad tanks.js
+++ b/examples/input/gamepad tanks.js
@@ -2,7 +2,7 @@
 // Steer with left analog, accelerate/brake with analog triggers,
 // fire with A and steer turret with left and right 'bumper' (shoulder) buttons.
 
-EnemyTank = function (index, game, player, bullets) {
+var EnemyTank = function (index, game, player, bullets) {
 
     var x = game.world.randomX;
     var y = game.world.randomY;

--- a/examples/input/override default controls.js
+++ b/examples/input/override default controls.js
@@ -4,6 +4,7 @@ var game = new Phaser.Game(800, 600, Phaser.CANVAS, 'phaser-example', { preload:
 var ufo;
 var leftBtn;
 var rightBtn;
+var spaceBtn;
 var speed = 4;
 
 function preload() {

--- a/examples/input/snap on drag.js
+++ b/examples/input/snap on drag.js
@@ -13,8 +13,8 @@ function create() {
 
     game.add.sprite(0, 0, 'grid');
 
-    atari1 = game.add.sprite(128, 128, 'atari1');
-    atari2 = game.add.sprite(256, 256, 'atari2');
+    var atari1 = game.add.sprite(128, 128, 'atari1');
+    var atari2 = game.add.sprite(256, 256, 'atari2');
 
     //  Input Enable the sprites
     atari1.inputEnabled = true;

--- a/examples/input/touch joystick.js
+++ b/examples/input/touch joystick.js
@@ -47,8 +47,8 @@ function create() {
     // because it's positioned relatively...
     // You probably don't need to do this in your game unless your game's canvas is positioned in a manner
     // similar to this example page, where the canvas isn't the whole screen.
-    $('canvas').last().css('z-index', 20);
-    $('canvas').last().offset( $('canvas').first().offset() );
+    jQuery('canvas').last().css('z-index', 20);
+    jQuery('canvas').last().offset( jQuery('canvas').first().offset() );
 }
 
 function update() {

--- a/examples/input/virtual gamecontroller.js
+++ b/examples/input/virtual gamecontroller.js
@@ -18,8 +18,6 @@ var duck= false;
 var fire=false;
 var jump=false;
 
-
-
 function preload() {
     //spritesheet for animations
     game.load.spritesheet('mario', 'assets/misc/mariospritesheet-small.png',50,50); // key, sourcefile, framesize x, framesize y
@@ -47,8 +45,8 @@ function create() {
     game.physics.p2.setBoundsToWorld(true, true, false, true, false); //(left, right, top, bottom, setCollisionGroup)
     game.physics.p2.friction = 5;   // default friction between ground and player or fireballs
 
-    clouds = game.add.tileSprite(0, 0, 2048, 600, 'clouds'); //add tiling sprite to cover the whole game world
-    ground = game.add.sprite(game.world.width/2, game.world.height-24,'ground');
+    var clouds = game.add.tileSprite(0, 0, 2048, 600, 'clouds'); //add tiling sprite to cover the whole game world
+    var ground = game.add.sprite(game.world.width/2, game.world.height-24,'ground');
     game.physics.p2.enable(ground);  //enable physics so our player will not fall through ground but collide with it
     ground.body.static=true;    // ground should not move
 
@@ -69,55 +67,55 @@ function create() {
     game.camera.follow(player); //always center player
 
     // create our virtual game controller buttons 
-    buttonjump = game.add.button(600, 500, 'buttonjump', null, this, 0, 1, 0, 1);  //game, x, y, key, callback, callbackContext, overFrame, outFrame, downFrame, upFrame
+    var buttonjump = game.add.button(600, 500, 'buttonjump', null, this, 0, 1, 0, 1);  //game, x, y, key, callback, callbackContext, overFrame, outFrame, downFrame, upFrame
     buttonjump.fixedToCamera = true;  //our buttons should stay on the same place  
     buttonjump.events.onInputOver.add(function(){jump=true;});
     buttonjump.events.onInputOut.add(function(){jump=false;});
     buttonjump.events.onInputDown.add(function(){jump=true;});
     buttonjump.events.onInputUp.add(function(){jump=false;});
 
-    buttonfire = game.add.button(700, 500, 'buttonfire', null, this, 0, 1, 0, 1);
+    var buttonfire = game.add.button(700, 500, 'buttonfire', null, this, 0, 1, 0, 1);
     buttonfire.fixedToCamera = true;
     buttonfire.events.onInputOver.add(function(){fire=true;});
     buttonfire.events.onInputOut.add(function(){fire=false;});
     buttonfire.events.onInputDown.add(function(){fire=true;});
     buttonfire.events.onInputUp.add(function(){fire=false;});        
 
-    buttonleft = game.add.button(0, 472, 'buttonhorizontal', null, this, 0, 1, 0, 1);
+    var buttonleft = game.add.button(0, 472, 'buttonhorizontal', null, this, 0, 1, 0, 1);
     buttonleft.fixedToCamera = true;
     buttonleft.events.onInputOver.add(function(){left=true;});
     buttonleft.events.onInputOut.add(function(){left=false;});
     buttonleft.events.onInputDown.add(function(){left=true;});
     buttonleft.events.onInputUp.add(function(){left=false;});
 
-    buttonbottomleft = game.add.button(32, 536, 'buttondiagonal', null, this, 6, 4, 6, 4);
+    var buttonbottomleft = game.add.button(32, 536, 'buttondiagonal', null, this, 6, 4, 6, 4);
     buttonbottomleft.fixedToCamera = true;
     buttonbottomleft.events.onInputOver.add(function(){left=true;duck=true;});
     buttonbottomleft.events.onInputOut.add(function(){left=false;duck=false;});
     buttonbottomleft.events.onInputDown.add(function(){left=true;duck=true;});
     buttonbottomleft.events.onInputUp.add(function(){left=false;duck=false;});
 
-    buttonright = game.add.button(160, 472, 'buttonhorizontal', null, this, 0, 1, 0, 1);
+    var buttonright = game.add.button(160, 472, 'buttonhorizontal', null, this, 0, 1, 0, 1);
     buttonright.fixedToCamera = true;
     buttonright.events.onInputOver.add(function(){right=true;});
     buttonright.events.onInputOut.add(function(){right=false;});
     buttonright.events.onInputDown.add(function(){right=true;});
     buttonright.events.onInputUp.add(function(){right=false;});
 
-    buttonbottomright = game.add.button(160, 536, 'buttondiagonal', null, this, 7, 5, 7, 5);
+    var buttonbottomright = game.add.button(160, 536, 'buttondiagonal', null, this, 7, 5, 7, 5);
     buttonbottomright.fixedToCamera = true;
     buttonbottomright.events.onInputOver.add(function(){right=true;duck=true;});
     buttonbottomright.events.onInputOut.add(function(){right=false;duck=false;});
     buttonbottomright.events.onInputDown.add(function(){right=true;duck=true;});
     buttonbottomright.events.onInputUp.add(function(){right=false;duck=false;});
 
-    buttondown = game.add.button(96, 536, 'buttonvertical', null, this, 0, 1, 0, 1);
+    var buttondown = game.add.button(96, 536, 'buttonvertical', null, this, 0, 1, 0, 1);
     buttondown.fixedToCamera = true;
     buttondown.events.onInputOver.add(function(){duck=true;});
     buttondown.events.onInputOut.add(function(){duck=false;});
     buttondown.events.onInputDown.add(function(){duck=true;});
     buttondown.events.onInputUp.add(function(){duck=false;});
-};
+}
 
 function update() {
     // define what should happen when a button is pressed
@@ -151,8 +149,8 @@ function update() {
     if (jump){ jump_now(); player.loadTexture('mario', 5);}  //change to another frame of the spritesheet
     if (fire){fire_now(); player.loadTexture('mario', 8); }
     if (duck){ player.body.setCircle(16,0,6);}else{ player.body.setCircle(22);}  //when ducking create a smaller hitarea - (radius,offsetx,offsety)
-    if (game.input.currentPointers == 0 && !game.input.activePointer.isMouse){ fire=false; right=false; left=false; duck=false; jump=false;} //this works around a "bug" where a button gets stuck in pressed state
-};
+    if (!game.input.currentPointers && !game.input.activePointer.isMouse){ fire=false; right=false; left=false; duck=false; jump=false;} //this works around a "bug" where a button gets stuck in pressed state
+}
 
 function render(){
     game.debug.text('jump:' + jump + ' duck:' + duck + ' left:' + left + ' right:' + right + ' fire:' + fire, 20, 20);

--- a/examples/loader/load binary file.js
+++ b/examples/loader/load binary file.js
@@ -38,7 +38,7 @@ function create() {
     var text = game.add.text(32, 32, "Signature: " + signature, { fill: '#ffffff' });
     text.setShadow(2, 2, 'rgba(0,0,0,0.5)', 0);
 
-    var title = getString(buffer, 0, 20)
+    var title = getString(buffer, 0, 20);
     var text2 = game.add.text(32, 64, "Title: " + title, { fill: '#ffffff' });
     text2.setShadow(2, 2, 'rgba(0,0,0,0.5)', 0);
 

--- a/examples/misc/device.js
+++ b/examples/misc/device.js
@@ -6,10 +6,10 @@ function create () {
 
 function render () {
 
-    game.debug.text('Navigator: ' + navigator.userAgent, 32, 32);
+    game.debug.text('Navigator: ' + window.navigator.userAgent, 32, 32);
     game.debug.text('iOS: ' + game.device.iOS, 32, 64);
     game.debug.text('Mobile Safari: ' + game.device.mobileSafari, 32, 98);
     game.debug.text('WebApp: ' + game.device.webApp, 32, 128);
-    game.debug.text('nav: ' + navigator['standalone'], 32, 128+32);
+    game.debug.text('nav: ' + window.navigator['standalone'], 32, 128+32);
 
 }

--- a/examples/misc/pause menu.js
+++ b/examples/misc/pause menu.js
@@ -2,6 +2,8 @@
 var game = new Phaser.Game(800, 600, Phaser.AUTO, 'phaser-example', { preload: preload, create: create });
 
 var w = 800, h = 600;
+var menu;
+var choiseLabel;
 
 function preload() {
     game.load.image('diamond', 'assets/sprites/diamond.png');
@@ -13,7 +15,7 @@ function create() {
         Code from example diamond burst
     */
     game.stage.backgroundColor = '#337799';
-    emitter = game.add.emitter(game.world.centerX, 100, 200);
+    var emitter = game.add.emitter(game.world.centerX, 100, 200);
     emitter.makeParticles('diamond');
     emitter.start(false, 5000, 20);
 
@@ -23,7 +25,7 @@ function create() {
     */
 
     // Create a label to use as a button
-    pause_label = game.add.text(w - 100, 20, 'Pause', { font: '24px Arial', fill: '#fff' });
+    var pause_label = game.add.text(w - 100, 20, 'Pause', { font: '24px Arial', fill: '#fff' });
     pause_label.inputEnabled = true;
     pause_label.events.onInputUp.add(function () {
         // When the paus button is pressed, we pause the game
@@ -39,7 +41,7 @@ function create() {
     });
 
     // Add a input listener that can help us return from being paused
-    game.input.onDown.add(unpause, self);
+    game.input.onDown.add(unpause);
 
     // And finally the method that handels the pause menu
     function unpause(event){
@@ -73,6 +75,6 @@ function create() {
                 game.paused = false;
             }
         }
-    };
+    }
 }
 

--- a/examples/misc/weighted pick.js
+++ b/examples/misc/weighted pick.js
@@ -17,7 +17,7 @@ function create() {
 
     for (var i = 0; i < 1000000; i++)
     {
-        rnd = this.game.rnd.weightedPick(test);
+        var rnd = this.game.rnd.weightedPick(test);
 
         total[rnd]++;
     }
@@ -33,7 +33,7 @@ function create() {
         list.push([i, total[i]]);
     }
 
-    text = game.add.text(200, 64, '', style);
+    var text = game.add.text(200, 64, '', style);
     text.parseList(list);
 
 }

--- a/examples/ninja physics/ninja platforms.js
+++ b/examples/ninja physics/ninja platforms.js
@@ -2,6 +2,10 @@ var game = new Phaser.Game(800, 600, Phaser.AUTO, 'phaser-example', this);
 
 var score = 0;
 var scoreText;
+var player;
+var diamond;
+var platforms;
+var cursors;
 
 function preload() {
 

--- a/examples/p2 physics/accelerate to object.js
+++ b/examples/p2 physics/accelerate to object.js
@@ -1,5 +1,9 @@
 var game = new Phaser.Game(800, 600, Phaser.AUTO, 'phaser-example', { preload: preload, create: create, update:update });
 
+var ship;
+var bullets;
+var cursors;
+
 function preload() {
     game.load.image('car', 'assets/sprites/car.png');
     game.load.image('tinycar', 'assets/sprites/tinycar.png');
@@ -15,7 +19,7 @@ function create() {
     cursors = game.input.keyboard.createCursorKeys();
     ship = game.add.sprite(32, game.world.height - 150, 'car');
     game.physics.p2.enable(ship);
-};
+}
 
 function update() {
     bullets.forEachAlive(moveBullets,this);  //make bullets accelerate to ship
@@ -25,7 +29,7 @@ function update() {
     else {ship.body.setZeroRotation();}
     if (cursors.up.isDown){ship.body.thrust(400);}
     else if (cursors.down.isDown){ship.body.reverse(400);}
-};
+}
 
 
 function moveBullets (bullet) { 

--- a/examples/p2 physics/basic movement.js
+++ b/examples/p2 physics/basic movement.js
@@ -31,7 +31,7 @@ function create() {
 	sprite.body.setZeroDamping();
 	sprite.body.fixedRotation = true;
 
-    text = game.add.text(20, 20, 'move with arrow keys', { fill: '#ffffff' });
+    game.add.text(20, 20, 'move with arrow keys', { fill: '#ffffff' });
 
     cursors = game.input.keyboard.createCursorKeys();
 

--- a/examples/p2 physics/chain.js
+++ b/examples/p2 physics/chain.js
@@ -29,6 +29,7 @@ function createRope(length, xAnchor, yAnchor) {
     {
         var x = xAnchor;                    //  All rects are on the same x position
         var y = yAnchor + (i * height);     //  Every new rect is positioned below the last
+        var newRect;
 
         if (i % 2 === 0)
         {

--- a/examples/p2 physics/collide custom bounds.js
+++ b/examples/p2 physics/collide custom bounds.js
@@ -9,6 +9,7 @@ function preload() {
 }
 
 var ship;
+var balls;
 var cursors;
 var customBounds;
 

--- a/examples/p2 physics/contact material.js
+++ b/examples/p2 physics/contact material.js
@@ -46,7 +46,7 @@ function create() {
     contactMaterial.frictionRelaxation = 3;     // Relaxation of the resulting FrictionEquation that this ContactMaterial generate.
     contactMaterial.surfaceVelocity = 0;        // Will add surface velocity to this material. If bodyA rests on top if bodyB, and the surface velocity is positive, bodyA will slide to the right.
 
-    text = game.add.text(20, 20, 'move with arrow keys', { fill: '#ffffff' });
+    game.add.text(20, 20, 'move with arrow keys', { fill: '#ffffff' });
 
     cursors = game.input.keyboard.createCursorKeys();
 

--- a/examples/p2 physics/distance constraint.js
+++ b/examples/p2 physics/distance constraint.js
@@ -28,7 +28,7 @@ function create() {
 
     var constraint = game.physics.p2.createDistanceConstraint(sprite1, sprite2, 150);
 
-    text = game.add.text(20, 20, 'move with arrow keys', { fill: '#ffffff' });
+    game.add.text(20, 20, 'move with arrow keys', { fill: '#ffffff' });
 
     cursors = game.input.keyboard.createCursorKeys();
 

--- a/examples/p2 physics/gear constraint.js
+++ b/examples/p2 physics/gear constraint.js
@@ -33,7 +33,7 @@ function create() {
     //  This constraint will make sure that as sprite rotates, sonic2 matches that rotation at half the ratio
     var constraint2 = game.physics.p2.createGearConstraint(sprite, sonic2, 0, 0.5);
 
-    text = game.add.text(20, 20, 'rotate with arrow keys', { fill: '#ffffff' });
+    game.add.text(20, 20, 'rotate with arrow keys', { fill: '#ffffff' });
 
     cursors = game.input.keyboard.createCursorKeys();
 

--- a/examples/p2 physics/gravity.js
+++ b/examples/p2 physics/gravity.js
@@ -31,7 +31,7 @@ function create() {
 
 	sprite.body.fixedRotation = true;
 
-    text = game.add.text(20, 20, 'click to the left / right of the ship', { fill: '#ffffff', font: '14pt Arial' });
+    game.add.text(20, 20, 'click to the left / right of the ship', { fill: '#ffffff', font: '14pt Arial' });
 
 	game.input.onDown.add(launch, this);
 

--- a/examples/p2 physics/kill and revive.js
+++ b/examples/p2 physics/kill and revive.js
@@ -31,7 +31,7 @@ function create() {
 	sprite.body.setZeroDamping();
 	sprite.body.fixedRotation = true;
 
-    text = game.add.text(20, 20, 'move with arrow keys, click to kill and reset', { fill: '#ffffff' });
+    game.add.text(20, 20, 'move with arrow keys, click to kill and reset', { fill: '#ffffff' });
 
     game.input.onDown.add(deathToggle, this);
 

--- a/examples/p2 physics/kinematic body.js
+++ b/examples/p2 physics/kinematic body.js
@@ -9,8 +9,8 @@ function preload() {
 
 }
 
-var static1;
-var static2;
+var kinematic1;
+var kinematic2;
 var sprite;
 var cursors;
 
@@ -48,7 +48,7 @@ function create() {
     kinematic1.body.velocity.x = 10;
     kinematic2.body.velocity.x = -10;
 
-    text = game.add.text(20, 20, 'move with arrow keys', { fill: '#ffffff' });
+    game.add.text(20, 20, 'move with arrow keys', { fill: '#ffffff' });
 
     cursors = game.input.keyboard.createCursorKeys();
 

--- a/examples/p2 physics/lock constraint.js
+++ b/examples/p2 physics/lock constraint.js
@@ -29,7 +29,7 @@ function create() {
     //  Lock the two bodies together. The [0, 50] sets the distance apart (y: 80)
     var constraint = game.physics.p2.createLockConstraint(sprite, vu1, [0, 80], 0);
 
-    text = game.add.text(20, 20, 'move with arrow keys', { fill: '#ffffff' });
+    game.add.text(20, 20, 'move with arrow keys', { fill: '#ffffff' });
 
     cursors = game.input.keyboard.createCursorKeys();
 

--- a/examples/p2 physics/movement constraint.js
+++ b/examples/p2 physics/movement constraint.js
@@ -9,13 +9,13 @@ function preload() {
 
 }
 
-var sprite1;
+var sprite2;
 var player;
 var cursors;
 
 function create() {
 
-    bg = game.add.tileSprite(0, 0, 800, 600, 'background');
+    game.add.tileSprite(0, 0, 800, 600, 'background');
 
 	//	Enable p2 physics
 	game.physics.startSystem(Phaser.Physics.P2JS);

--- a/examples/p2 physics/platformer material.js
+++ b/examples/p2 physics/platformer material.js
@@ -20,7 +20,7 @@ var yAxis = p2.vec2.fromValues(0, 1);
 
 function create() {
 
-    bg = game.add.tileSprite(0, 0, 800, 600, 'background');
+    game.add.tileSprite(0, 0, 800, 600, 'background');
 
     //  Enable p2 physics
     game.physics.startSystem(Phaser.Physics.P2JS);
@@ -74,7 +74,7 @@ function create() {
     // contactMaterial.frictionRelaxation = 3;     // Relaxation of the resulting FrictionEquation that this ContactMaterial generate.
     // contactMaterial.surfaceVelocity = 0.0;        // Will add surface velocity to this material. If bodyA rests on top if bodyB, and the surface velocity is positive, bodyA will slide to the right.
 
-    text = game.add.text(20, 20, 'move with arrow, space to jump', { fill: '#ffffff' });
+    game.add.text(20, 20, 'move with arrow, space to jump', { fill: '#ffffff' });
 
     cursors = game.input.keyboard.createCursorKeys();
     jumpButton = game.input.keyboard.addKey(Phaser.Keyboard.SPACEBAR);

--- a/examples/p2 physics/postbroadphase callback.js
+++ b/examples/p2 physics/postbroadphase callback.js
@@ -11,6 +11,7 @@ function preload() {
 
 var ship;
 var starfield;
+var veggies;
 var cursors;
 
 function create() {

--- a/examples/p2 physics/prismatic constraint.js
+++ b/examples/p2 physics/prismatic constraint.js
@@ -40,7 +40,7 @@ function create() {
     constraint.lowerLimit = game.physics.p2.pxm(-0.5);
     */
 
-    text = game.add.text(20, 20, 'move with arrow keys', { fill: '#ffffff' });
+    game.add.text(20, 20, 'move with arrow keys', { fill: '#ffffff' });
 
     cursors = game.input.keyboard.createCursorKeys();
 

--- a/examples/p2 physics/remove spring.js
+++ b/examples/p2 physics/remove spring.js
@@ -35,7 +35,7 @@ function create() {
     //  See the docs for more details
     spring = game.physics.p2.createSpring(sprite1, sprite2, 20, 10, 1);
 
-    text = game.add.text(20, 20, 'move with arrow keys, click to remove spring', { fill: '#ffffff' });
+    game.add.text(20, 20, 'move with arrow keys, click to remove spring', { fill: '#ffffff' });
 
     cursors = game.input.keyboard.createCursorKeys();
 

--- a/examples/p2 physics/revolute constraint.js
+++ b/examples/p2 physics/revolute constraint.js
@@ -32,7 +32,7 @@ function create() {
 
     var constraint = game.physics.p2.createRevoluteConstraint(sprite, [ 50, 100 ], vu1, [ 0, 0 ]);
 
-    text = game.add.text(20, 20, 'rotate with arrow keys', { fill: '#ffffff' });
+    game.add.text(20, 20, 'rotate with arrow keys', { fill: '#ffffff' });
 
     cursors = game.input.keyboard.createCursorKeys();
 

--- a/examples/p2 physics/springs.js
+++ b/examples/p2 physics/springs.js
@@ -34,7 +34,7 @@ function create() {
     //  See the docs for more details
     var spring = game.physics.p2.createSpring(sprite1, sprite2, 20, 10, 1);
 
-    text = game.add.text(20, 20, 'move with arrow keys', { fill: '#ffffff' });
+    game.add.text(20, 20, 'move with arrow keys', { fill: '#ffffff' });
 
     cursors = game.input.keyboard.createCursorKeys();
 

--- a/examples/p2 physics/state reset.js
+++ b/examples/p2 physics/state reset.js
@@ -2,12 +2,12 @@ var P2Game = {};
 
 P2Game.StateA = function (game) {
 
-    this.contra;
-    this.block;
-    this.tetris1;
-    this.changeTimer;
+    this.contra = undefined;
+    this.block = undefined;
+    this.tetris1 = undefined;
+    this.changeTimer = undefined;
 
-    this.cursors;
+    this.cursors = undefined;
 
     this.result = 'Move with cursors. Hit an object to change State';
 
@@ -124,12 +124,12 @@ P2Game.StateA.prototype = {
 
 P2Game.StateB = function (game) {
 
-    this.contra;
-    this.block;
-    this.tetris1;
-    this.changeTimer;
+    this.contra = undefined;
+    this.block = undefined;
+    this.tetris1 = undefined;
+    this.changeTimer = undefined;
 
-    this.cursors;
+    this.cursors = undefined;
 
     this.result = 'Move with cursors. Hit an object to change State';
 
@@ -236,12 +236,12 @@ P2Game.StateB.prototype = {
 
 P2Game.StateC = function (game) {
 
-    this.contra;
-    this.block;
-    this.tetris1;
-    this.changeTimer;
+    this.contra = undefined;
+    this.block = undefined;
+    this.tetris1 = undefined;
+    this.changeTimer = undefined;
 
-    this.cursors;
+    this.cursors = undefined;
 
     this.result = 'Move with cursors. Hit an object to change State';
 

--- a/examples/p2 physics/static body.js
+++ b/examples/p2 physics/static body.js
@@ -40,7 +40,7 @@ function create() {
     static1.body.static = true;
 	static2.body.static = true;
 
-    text = game.add.text(20, 20, 'move with arrow keys', { fill: '#ffffff' });
+    game.add.text(20, 20, 'move with arrow keys', { fill: '#ffffff' });
 
     cursors = game.input.keyboard.createCursorKeys();
 

--- a/examples/p2 physics/tilemap gravity.js
+++ b/examples/p2 physics/tilemap gravity.js
@@ -128,8 +128,14 @@ function checkIfCanJump() {
         if (c.bodyA === player.body.data || c.bodyB === player.body.data)
         {
             var d = p2.vec2.dot(c.normalA, yAxis); // Normal dot Y-axis
-            if (c.bodyA === player.body.data) d *= -1;
-            if (d > 0.5) result = true;
+            if (c.bodyA === player.body.data)
+            {
+                d *= -1;
+            }
+            if (d > 0.5)
+            {
+                result = true;
+            }
         }
     }
     

--- a/examples/p2 physics/tilesprite.js
+++ b/examples/p2 physics/tilesprite.js
@@ -10,6 +10,7 @@ function preload() {
 }
 
 var sprite;
+var veggies;
 var cursors;
 
 function create() {
@@ -40,7 +41,7 @@ function create() {
         veg.body.setCircle(26);
     }
 
-    text = game.add.text(20, 20, 'move with arrow keys', { fill: '#ffffff' });
+    game.add.text(20, 20, 'move with arrow keys', { fill: '#ffffff' });
 
     cursors = game.input.keyboard.createCursorKeys();
 

--- a/examples/p2 physics/world move.js
+++ b/examples/p2 physics/world move.js
@@ -11,6 +11,7 @@ function preload() {
 
 var ship;
 var starfield;
+var balls;
 var cursors;
 
 function create() {

--- a/examples/particles/particle class.js
+++ b/examples/particles/particle class.js
@@ -1,6 +1,6 @@
 
 //  Here is our custom Particle
-MonsterParticle = function (game, x, y) {
+var MonsterParticle = function (game, x, y) {
 
     Phaser.Particle.call(this, game, x, y, game.cache.getBitmapData('particleShade'));
 
@@ -10,6 +10,8 @@ MonsterParticle.prototype = Object.create(Phaser.Particle.prototype);
 MonsterParticle.prototype.constructor = MonsterParticle;
 
 var game = new Phaser.Game(800, 600, Phaser.CANVAS, 'phaser-example', { create: create, render: render });
+
+var emitter;
 
 function create() {
 

--- a/examples/particles/snow.js
+++ b/examples/particles/snow.js
@@ -78,8 +78,8 @@ function changeWindDirection() {
         frag = (Math.floor(Math.random() * 100) - multi);
     max = max + frag;
 
-    if (max > 200) max = 150;
-    if (max < -200) max = -150;
+    if (max > 200) { max = 150; }
+    if (max < -200) { max = -150; }
 
     setXSpeed(back_emitter, max);
     setXSpeed(mid_emitter, max);

--- a/examples/particles/world particles.js
+++ b/examples/particles/world particles.js
@@ -2,6 +2,7 @@
 // var game = new Phaser.Game(800, 600, Phaser.AUTO, 'phaser-example', { preload: preload, create: create, update: update, render: render });
 var game = new Phaser.Game(800, 600, Phaser.CANVAS, 'phaser-example', { preload: preload, create: create, update: update, render: render });
 
+var cursors;
 var emitter;
 
 function preload() {

--- a/examples/sprites/extending sprite demo 1.js
+++ b/examples/sprites/extending sprite demo 1.js
@@ -1,6 +1,6 @@
 
 //  Here is a custom game object
-MonsterBunny = function (game, x, y, rotateSpeed) {
+var MonsterBunny = function (game, x, y, rotateSpeed) {
 
     Phaser.Sprite.call(this, game, x, y, 'bunny');
 

--- a/examples/sprites/extending sprite demo 2.js
+++ b/examples/sprites/extending sprite demo 2.js
@@ -1,5 +1,5 @@
 
-MonsterBunny = function (game, rotateSpeed) {
+var MonsterBunny = function (game, rotateSpeed) {
 
     //  We call the Phaser.Sprite passing in the game reference
     //  We're giving it a random X/Y position here, just for the sake of this demo - you could also pass the x/y in the constructor
@@ -11,9 +11,7 @@ MonsterBunny = function (game, rotateSpeed) {
 
     var randomScale = 0.1 + Math.random();
 
-    this.scale.setTo(randomScale, randomScale)
-
-    game.add.existing(this);
+    this.scale.setTo(randomScale, randomScale);
 
 };
 
@@ -39,7 +37,8 @@ function create() {
 
     for (var i = 0.1; i < 2; i += 0.1)
     {
-        new MonsterBunny(game, i);
+        var monster = new MonsterBunny(game, i);
+        game.add.existing(monster);
     }
 
 }

--- a/examples/text/bitmap fonts.js
+++ b/examples/text/bitmap fonts.js
@@ -7,7 +7,7 @@ function preload() {
 
 }
 
-var bpmText;
+var bmpText;
 
 function create() {
 

--- a/examples/text/bitmapfont drag.js
+++ b/examples/text/bitmapfont drag.js
@@ -7,7 +7,7 @@ function preload() {
 
 }
 
-var bpmText;
+var bmpText;
 
 function create() {
 

--- a/examples/text/bitmaptext max width.js
+++ b/examples/text/bitmaptext max width.js
@@ -7,7 +7,7 @@ function preload() {
 
 }
 
-var bpmText;
+var bmpText;
 var text = "Lorem ipsum ";
 var words = [ 
     'dolor', 'sit', 'amet', 'consectetuer', 'adipiscing', 'elit', 'aenean', 

--- a/examples/text/bitmaptext purge glyphs.js
+++ b/examples/text/bitmaptext purge glyphs.js
@@ -7,7 +7,7 @@ function preload() {
 
 }
 
-var bpmText;
+var bmpText;
 var text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quid ergo aliud intellegetur nisi uti ne quae pars naturae neglegatur? Si longus, levis; Ita relinquet duas, de quibus etiam atque etiam consideret. Optime, inquam. Sed quanta sit alias, nunc tantum possitne esse tanta.\n\nQuid, si etiam iucunda memoria est praeteritorum malorum? Consequatur summas voluptates non modo parvo, sed per me nihilo, si potest; Atque his de rebus et splendida est eorum et illustris oratio. Mihi enim satis est, ipsis non satis. Ergo ita: non posse honeste vivi, nisi honeste vivatur? Mihi quidem Antiochum, quem audis, satis belle videris attendere. Et quod est munus, quod opus sapientiae? Ex rebus enim timiditas, non ex vocabulis nascitur. Ex ea difficultate illae fallaciloquae, ut ait Accius, malitiae natae sunt. Nonne videmus quanta perturbatio rerum omnium consequatur, quanta confusio? Quae cum magnifice primo dici viderentur, considerata minus probabantur.\n\n---> Click to remove text";
 
 function create() {

--- a/examples/text/display text word by word.js
+++ b/examples/text/display text word by word.js
@@ -27,6 +27,7 @@ var content = [
 ];
 
 var line = [];
+var text;
 
 var wordIndex = 0;
 var lineIndex = 0;

--- a/examples/text/dynamic text shadow.js
+++ b/examples/text/dynamic text shadow.js
@@ -41,9 +41,9 @@ function moveToXY(displayObject, x, y, speed) {
 
     var _angle = Math.atan2(y - displayObject.y, x - displayObject.x);
     
-    var x = Math.cos(_angle) * speed;
-    var y = Math.sin(_angle) * speed;
+    var newX = Math.cos(_angle) * speed;
+    var newY = Math.sin(_angle) * speed;
 
-    return { x: x, y: y };
+    return { x: newX, y: newY };
 
 }

--- a/examples/text/extending text.js
+++ b/examples/text/extending text.js
@@ -1,4 +1,4 @@
-CustomText = function (game, x, y, text) {
+var CustomText = function (game, x, y, text) {
 
     Phaser.Text.call(this, game, x, y, text, { font: "65px Arial", fill: "#ff0044", align: "center" });
 

--- a/examples/text/google webfonts.js
+++ b/examples/text/google webfonts.js
@@ -2,7 +2,7 @@
 var game = new Phaser.Game(800, 600, Phaser.CANVAS, 'phaser-example', { preload: preload, create: create });
 
 //  The Google WebFont Loader will look for this object, so create it before loading the script.
-WebFontConfig = {
+var WebFontConfig = {
 
     //  'active' means all requested fonts have finished loading
     //  We set a 1 second delay before calling 'createText'.

--- a/examples/text/text padding.js
+++ b/examples/text/text padding.js
@@ -2,7 +2,7 @@
 var game = new Phaser.Game(800, 600, Phaser.CANVAS, 'phaser-example', { preload: preload, create: create });
 
 //  The Google WebFont Loader will look for this object, so create it before loading the script.
-WebFontConfig = {
+var WebFontConfig = {
 
     //  'active' means all requested fonts have finished loading
     //  We set a 1 second delay before calling 'createText'.

--- a/examples/text/text tabs with google font.js
+++ b/examples/text/text tabs with google font.js
@@ -2,7 +2,7 @@
 var game = new Phaser.Game(800, 600, Phaser.CANVAS, 'phaser-example', { preload: preload, create: create });
 
 //  The Google WebFont Loader will look for this object, so create it before loading the script.
-WebFontConfig = {
+var WebFontConfig = {
 
     //  'active' means all requested fonts have finished loading
     //  We set a 1 second delay before calling 'createText'.

--- a/examples/tile sprites/animated tiling sprite.js
+++ b/examples/tile sprites/animated tiling sprite.js
@@ -20,7 +20,7 @@ function create() {
 
 function update() {
 
-    count += 0.005
+    count += 0.005;
 
     tilesprite.tileScale.x = 2 + Math.sin(count);
     tilesprite.tileScale.y = 2 + Math.cos(count);

--- a/examples/tilemaps/paint tiles.js
+++ b/examples/tilemaps/paint tiles.js
@@ -50,7 +50,7 @@ function update() {
         {
             if (map.getTile(layer.getTileX(marker.x), layer.getTileY(marker.y)) != currentTile)
             {
-                map.putTile(currentTile, layer.getTileX(marker.x), layer.getTileY(marker.y))
+                map.putTile(currentTile, layer.getTileX(marker.x), layer.getTileY(marker.y));
             }
         }
     }

--- a/examples/tilemaps/tileset from bitmapdata.js
+++ b/examples/tilemaps/tileset from bitmapdata.js
@@ -6,6 +6,7 @@ var map;
 var layer;
 var marker;
 var currentTile = 0;
+var currentTileMarker;
 var cursors;
 var player;
 var facing = 'left';

--- a/examples/time/slow down time.js
+++ b/examples/time/slow down time.js
@@ -93,6 +93,7 @@ function handleFpsProblem() {
 
 }
 
+/* jshint ignore:start */
 //
 // dat.GUI minified
 //
@@ -178,3 +179,4 @@ window.mozRequestAnimationFrame||window.oRequestAnimationFrame||window.msRequest
 document.createElement("div");a.extend(this.domElement.style,{position:"fixed",display:"none",zIndex:"1001",opacity:0,WebkitTransition:"-webkit-transform 0.2s ease-out, opacity 0.2s linear"});document.body.appendChild(this.backgroundElement);document.body.appendChild(this.domElement);var b=this;e.bind(this.backgroundElement,"click",function(){b.hide()})};b.prototype.show=function(){var b=this;this.backgroundElement.style.display="block";this.domElement.style.display="block";this.domElement.style.opacity=
 0;this.domElement.style.webkitTransform="scale(1.1)";this.layout();a.defer(function(){b.backgroundElement.style.opacity=1;b.domElement.style.opacity=1;b.domElement.style.webkitTransform="scale(1)"})};b.prototype.hide=function(){var a=this,b=function(){a.domElement.style.display="none";a.backgroundElement.style.display="none";e.unbind(a.domElement,"webkitTransitionEnd",b);e.unbind(a.domElement,"transitionend",b);e.unbind(a.domElement,"oTransitionEnd",b)};e.bind(this.domElement,"webkitTransitionEnd",
 b);e.bind(this.domElement,"transitionend",b);e.bind(this.domElement,"oTransitionEnd",b);this.backgroundElement.style.opacity=0;this.domElement.style.opacity=0;this.domElement.style.webkitTransform="scale(1.1)"};b.prototype.layout=function(){this.domElement.style.left=window.innerWidth/2-e.getWidth(this.domElement)/2+"px";this.domElement.style.top=window.innerHeight/2-e.getHeight(this.domElement)/2+"px"};return b}(dat.dom.dom,dat.utils.common),dat.dom.dom,dat.utils.common);
+/* jshint ignore:end */

--- a/examples/tweens/combined tweens.js
+++ b/examples/tweens/combined tweens.js
@@ -44,7 +44,7 @@ function firstTween() {
 
 function theEnd() {
     
-    e = game.add.tween(pig);
+    var e = game.add.tween(pig);
     
     e.to({ x: -150 }, 1000, Phaser.Easing.Bounce.Out);
     e.start();

--- a/examples/tweens/generate data.js
+++ b/examples/tweens/generate data.js
@@ -22,7 +22,7 @@ function create() {
     var tweenData = { x: 0, y: 0 };
 
     //  Here we'll tween the values held in the tweenData object to x: 500, y: 300
-    tween = game.make.tween(tweenData).to( { x: 100, y: 400 }, 2000, "Sine.easeInOut");
+    var tween = game.make.tween(tweenData).to( { x: 100, y: 400 }, 2000, "Sine.easeInOut");
 
     //  Set the tween to yoyo so it loops smoothly
     tween.yoyo(true);

--- a/examples/tweens/pause tween.js
+++ b/examples/tweens/pause tween.js
@@ -19,7 +19,7 @@ function create() {
 
     p = game.add.sprite(100, 100, 'diamond');
 
-    tween = game.add.tween(p).to({ x: 600 }, 4000, Phaser.Easing.Linear.None, true, 0, 1000, true)
+    tween = game.add.tween(p).to({ x: 600 }, 4000, Phaser.Easing.Linear.None, true, 0, 1000, true);
 
     button = game.add.button(game.world.centerX, 400, 'button', actionOnClick, this, 2, 1, 0);
 

--- a/examples/video/take snapshot from stream.js
+++ b/examples/video/take snapshot from stream.js
@@ -30,7 +30,7 @@ function camAllowed() {
     var grab = video.snapshot.addToWorld(game.width, game.height);
     grab.anchor.set(1);
 
-    game.add.text(400, 32, 'Click to grab', { font: "bold 26px Arial", fill: "#ffffff" })
+    game.add.text(400, 32, 'Click to grab', { font: "bold 26px Arial", fill: "#ffffff" });
 
     game.input.onDown.add(takeSnapshot, this);
 

--- a/examples/virtualjoystick/arcade joystick.js
+++ b/examples/virtualjoystick/arcade joystick.js
@@ -11,15 +11,15 @@ var game = new Phaser.Game(800, 600, Phaser.AUTO, 'phaser-example');
 
 var PhaserGame = function () {
 
-    this.sprite;
+    this.sprite = undefined;
 
-    this.pad;
+    this.pad = undefined;
 
-    this.stick;
+    this.stick = undefined;
 
-    this.buttonA;
-    this.buttonB;
-    this.buttonC;
+    this.buttonA = undefined;
+    this.buttonB = undefined;
+    this.buttonC = undefined;
 
 };
 

--- a/examples/virtualjoystick/buttons.js
+++ b/examples/virtualjoystick/buttons.js
@@ -11,13 +11,13 @@ var game = new Phaser.Game(800, 600, Phaser.AUTO, 'phaser-example');
 
 var PhaserGame = function () {
 
-    this.fx;
+    this.fx = undefined;
 
-    this.pad;
+    this.pad = undefined;
 
-    this.buttonA;
-    this.buttonB;
-    this.buttonC;
+    this.buttonA = undefined;
+    this.buttonB = undefined;
+    this.buttonC = undefined;
 
 };
 

--- a/examples/virtualjoystick/dpad.js
+++ b/examples/virtualjoystick/dpad.js
@@ -11,15 +11,15 @@ var game = new Phaser.Game(800, 600, Phaser.AUTO, 'phaser-example');
 
 var PhaserGame = function () {
 
-    this.sprite;
+    this.sprite = undefined;
 
-    this.pad;
+    this.pad = undefined;
 
-    this.stick;
+    this.stick = undefined;
 
-    this.buttonA;
-    this.buttonB;
-    this.buttonC;
+    this.buttonA = undefined;
+    this.buttonB = undefined;
+    this.buttonC = undefined;
 
 };
 

--- a/examples/virtualjoystick/dual sticks.js
+++ b/examples/virtualjoystick/dual sticks.js
@@ -11,14 +11,14 @@ var game = new Phaser.Game(800, 600, Phaser.AUTO, 'phaser-example');
 
 var PhaserGame = function () {
 
-    this.sprite;
-    this.bullets;
+    this.sprite = undefined;
+    this.bullets = undefined;
     this.bulletTime = 0;
 
-    this.pad;
+    this.pad = undefined;
 
-    this.stick1;
-    this.stick2;
+    this.stick1 = undefined;
+    this.stick2 = undefined;
 
 };
 

--- a/examples/virtualjoystick/generic joystick.js
+++ b/examples/virtualjoystick/generic joystick.js
@@ -11,15 +11,15 @@ var game = new Phaser.Game(800, 600, Phaser.AUTO, 'phaser-example');
 
 var PhaserGame = function () {
 
-    this.sprite;
+    this.sprite = undefined;
 
-    this.pad;
+    this.pad = undefined;
 
-    this.stick;
+    this.stick = undefined;
 
-    this.buttonA;
-    this.buttonB;
-    this.buttonC;
+    this.buttonA = undefined;
+    this.buttonB = undefined;
+    this.buttonC = undefined;
 
 };
 

--- a/examples/virtualjoystick/horizontal motion lock.js
+++ b/examples/virtualjoystick/horizontal motion lock.js
@@ -11,13 +11,13 @@ var game = new Phaser.Game(800, 600, Phaser.AUTO, 'phaser-example');
 
 var PhaserGame = function () {
 
-    this.sprite;
+    this.sprite = undefined;
 
-    this.pad;
+    this.pad = undefined;
 
-    this.stick;
+    this.stick = undefined;
 
-    this.buttonA;
+    this.buttonA = undefined;
 
 };
 

--- a/examples/virtualjoystick/shader motion.js
+++ b/examples/virtualjoystick/shader motion.js
@@ -11,11 +11,11 @@ var game = new Phaser.Game(800, 600, Phaser.AUTO, 'phaser-example');
 
 var PhaserGame = function () {
 
-    this.pad;
+    this.pad = undefined;
 
-    this.stick;
+    this.stick = undefined;
 
-    this.filter;
+    this.filter = undefined;
 
 };
 

--- a/examples/virtualjoystick/shoot em up.js
+++ b/examples/virtualjoystick/shoot em up.js
@@ -16,17 +16,17 @@ var PhaserGame = function () {
     this.player = null;
     this.speed = 300;
 
-    this.weapon1;
-    this.weapon2;
-    this.weapon3;
+    this.weapon1 = undefined;
+    this.weapon2 = undefined;
+    this.weapon3 = undefined;
 
-    this.pad;
+    this.pad = undefined;
 
-    this.stick;
+    this.stick = undefined;
 
-    this.buttonA;
-    this.buttonB;
-    this.buttonC;
+    this.buttonA = undefined;
+    this.buttonB = undefined;
+    this.buttonC = undefined;
 
 };
 

--- a/examples/virtualjoystick/show on touch.js
+++ b/examples/virtualjoystick/show on touch.js
@@ -11,11 +11,11 @@ var game = new Phaser.Game(800, 600, Phaser.AUTO, 'phaser-example');
 
 var PhaserGame = function () {
 
-    this.sprite;
+    this.sprite = undefined;
 
-    this.pad;
+    this.pad = undefined;
 
-    this.stick;
+    this.stick = undefined;
 
 };
 

--- a/examples/virtualjoystick/stick debug.js
+++ b/examples/virtualjoystick/stick debug.js
@@ -11,11 +11,11 @@ var game = new Phaser.Game(800, 600, Phaser.CANVAS, 'phaser-example');
 
 var PhaserGame = function () {
 
-    this.sprite;
+    this.sprite = undefined;
 
-    this.pad;
+    this.pad = undefined;
 
-    this.stick;
+    this.stick = undefined;
 
 };
 

--- a/examples/virtualjoystick/stick events.js
+++ b/examples/virtualjoystick/stick events.js
@@ -11,11 +11,11 @@ var game = new Phaser.Game(800, 600, Phaser.AUTO, 'phaser-example');
 
 var PhaserGame = function () {
 
-    this.sprite;
+    this.sprite = undefined;
 
-    this.pad;
+    this.pad = undefined;
 
-    this.stick;
+    this.stick = undefined;
 
 };
 

--- a/examples/virtualjoystick/stick position.js
+++ b/examples/virtualjoystick/stick position.js
@@ -11,13 +11,13 @@ var game = new Phaser.Game(800, 600, Phaser.AUTO, 'phaser-example');
 
 var PhaserGame = function () {
 
-    this.pad;
+    this.pad = undefined;
 
-    this.stick;
+    this.stick = undefined;
 
-    this.buttonA;
-    this.buttonB;
-    this.buttonC;
+    this.buttonA = undefined;
+    this.buttonB = undefined;
+    this.buttonC = undefined;
 
 };
 

--- a/examples/virtualjoystick/stick scale.js
+++ b/examples/virtualjoystick/stick scale.js
@@ -11,13 +11,13 @@ var game = new Phaser.Game(800, 600, Phaser.AUTO, 'phaser-example');
 
 var PhaserGame = function () {
 
-    this.sprite;
+    this.sprite = undefined;
 
-    this.pad;
+    this.pad = undefined;
 
-    this.stick1;
-    this.stick2;
-    this.stick3;
+    this.stick1 = undefined;
+    this.stick2 = undefined;
+    this.stick3 = undefined;
 
 };
 

--- a/examples/virtualjoystick/vertical motion lock.js
+++ b/examples/virtualjoystick/vertical motion lock.js
@@ -11,13 +11,13 @@ var game = new Phaser.Game(800, 600, Phaser.AUTO, 'phaser-example');
 
 var PhaserGame = function () {
 
-    this.sprite;
+    this.sprite = undefined;
 
-    this.pad;
+    this.pad = undefined;
 
-    this.stick;
+    this.stick = undefined;
 
-    this.buttonA;
+    this.buttonA = undefined;
 
 };
 

--- a/package.json
+++ b/package.json
@@ -28,12 +28,14 @@
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-cli": "~0.1.13",
+    "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-connect": "~0.5.0",
     "grunt-contrib-copy": "~0.5.0",
-    "grunt-contrib-clean": "~0.5.0",
+    "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-uglify": "~0.3.3",
-    "lodash": "~2.2.1",
-    "grunt-text-replace": "~0.3.11"
+    "grunt-text-replace": "~0.3.11",
+    "jshint": "^2.8.0",
+    "lodash": "~2.2.1"
   }
 }

--- a/tasks/jshint.json
+++ b/tasks/jshint.json
@@ -1,0 +1,30 @@
+{
+    "curly": true,
+    "debug": false,
+    "devel": false,
+    "eqnull": true,
+    "forin": false,
+    "immed": false,
+    "laxbreak": false,
+    "newcap": true,
+    "noarg": true,
+    "noempty": true,
+    "nonew": true,
+    "plusplus": false,
+    "strict": false,
+    "shadow": true,
+    "sub": true,
+    "trailing": true,
+    "undef": true,
+    "globals": {
+        "Phaser": false,
+        "PIXI": false,
+        "window": false,
+        "document": false,
+        "console": false,
+        "Uint8Array": false,
+        "setTimeout": false,
+        "jQuery": false
+    },
+    "white": false
+}


### PR DESCRIPTION
Adds jshint grunt task (`grunt jshint`) and provides hint-approved changes to examples.

Almost all jshint warnings are corrected except for 'redeclarations' within the same scope. (Maybe there an option to just suppress such?)

There are no explicit semantic changes and 'good effort' has been taken to remain consistent.
Variables are exposed as 'global' when it is likely they may be usefully inspected.

Removed some debug code and correct one or two as-of-yet-unreported issues.

Fixes #115 and similar issues
