### PR TITLE
alien moves out of bounds then back to a position out of bounds

### DIFF
--- a/examples/sprites/out of bounds.js
+++ b/examples/sprites/out of bounds.js
@@ -40,7 +40,7 @@ function create() {
 function alienOut(alien) {
 
     //  Move the alien to the top of the screen again
-    alien.reset(alien.x, -32);
+    alien.reset(alien.x, 0);
 
     //  And give it a new random velocity
     alien.body.velocity.y = 50 + Math.random() * 200;


### PR DESCRIPTION
When alienOut is called it was set to once again be outOfBounds (-32y) which caused the alien to never reappear on screen.
Simple fix to reset the alien to  0y instead, which causes intended wrapping behaviour.

Opt fix> increase bound size to be something else than setBoundsToWorld(), which causes bounds to be screensize.