### PR TITLE
Fix typo in variable name

### DIFF
--- a/examples/text/bitmap fonts.js
+++ b/examples/text/bitmap fonts.js
@@ -7,7 +7,7 @@ function preload() {
 
 }
 
-var bpmText;
+var bmpText;
 
 function create() {
 


### PR DESCRIPTION
Variable name as defined in line 10 has been edited to match variable name as used in lines 14 and 20. 
