### PR TITLE
Cleans up Matching Pairs timer by making it stop at zero.

### DIFF
--- a/examples/games/matching pairs.js
+++ b/examples/games/matching pairs.js
@@ -93,7 +93,9 @@ function countDownTimer() {
     if (myCountdownSeconds <= 0) 
         {
         // time is up
-        timesUp = 'Time is up!';    
+        timesUp = 'Time is up!'; 
+        myCountdownSeconds = 0;
+
     }
 }
 


### PR DESCRIPTION
Seems silly to keep the timer going well into the negative if the person already knows they've ran out of time.