### PR TITLE
Fix pointer lock

### DIFF
--- a/examples/input/pointer lock.js
+++ b/examples/input/pointer lock.js
@@ -27,8 +27,8 @@ function move(pointer, x, y) {
 
     if (game.input.mouse.locked)
     {
-        sprite.x += game.input.mouse.event.webkitMovementX;
-        sprite.y += game.input.mouse.event.webkitMovementY;
+        sprite.x += game.input.mouse.event.movementX;
+        sprite.y += game.input.mouse.event.movementY;
     }
 
 }


### PR DESCRIPTION
I've replaced webkitMovementX/Y with movementX/Y because Chrome no longer uses the webkit prefix, changing this will make it work for other browsers too.

http://caniuse.com/#feat=pointerlock
