### PR TITLE
Modified Pointer Lock example to not move sprite with click events

### DIFF
--- a/examples/input/pointer lock.js
+++ b/examples/input/pointer lock.js
@@ -23,9 +23,11 @@ function requestLock() {
     game.input.mouse.requestPointerLock();
 }
 
-function move(pointer, x, y) {
+function move(pointer, x, y, click) {
 
-    if (game.input.mouse.locked)
+    //  If the cursor is locked to the game, and the callback was not fired from a 'click' event
+    //  (such as a mouse click or touch down) - as then it might contain incorrect movement values
+    if (game.input.mouse.locked && !click)
     {
         sprite.x += game.input.mouse.event.movementX;
         sprite.y += game.input.mouse.event.movementY;


### PR DESCRIPTION
Relating to this seemingly Firefox-related issue:
https://github.com/photonstorm/phaser-examples/issues/163

Rather than using game.input.mouse.event.type like in the issue I
raised, this uses an extra parameter of Phaser's addMoveCallback to
check if the event was fired by a click event.

This "feels a bit weird" because addMoveCallback sounds like it
shouldn't deal with mousedown (etc.) events... but reading through
Phaser's source explained it quite well. I've tried to convey that a bit
with my extra comment in the example.

I also think this needs some further investigating, because what if you
want to have the pointer locked to the game, but only update it's
movement when the user clicks? This might only be possible in Chrome
right now, with the Firefox implementation of pointer lock giving
garbage movement values with mousedown events - or maybe it's Phaser
that calculates something incorrectly?