### PR TITLE
Uncommented pointer movement callback in Draw Sprite example

### DIFF
--- a/examples/bitmapdata/draw sprite.js
+++ b/examples/bitmapdata/draw sprite.js
@@ -32,7 +32,7 @@ function create() {
 
 	bmd.draw(crab, 10, 10);
 
-    // game.input.addMoveCallback(paint, this);
+        game.input.addMoveCallback(paint, this);
 
 }
 


### PR DESCRIPTION
It looks like some critical code was commented out in the Draw Sprite example.